### PR TITLE
Feature/mobile responsiveness tweaks

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
 }
 
 @theme inline {
+  --breakpoint-xs: 26rem; /* 416px */
   --color-background: #ffffff;
   --color-foreground: #171717;
   --color-home: #191D0E;

--- a/src/app/layoutWrapper.tsx
+++ b/src/app/layoutWrapper.tsx
@@ -56,7 +56,7 @@ export default function LayoutWrapper({ children }: { children: React.ReactNode 
   }, [pathname]);
 
   return (
-    <div className={`transition-colors duration-300 ease-in-out ${backgroundClass} min-h-screen`}>
+    <div className={`transition-colors duration-300 ease-in-out ${backgroundClass} h-dvh`}>
       <NavBar bgClass={navBgClass} altBgClass={navAltBgClass} />
       {children}
       <BottomNav bgClass={bottomNavBgClass} altBgClass={navBgClass} pathname={pathname} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
             lg:w-86 lg:h-[540px] lg:mt-22
             md:w-62 md:h-[440px] md:mt-32
             sm:w-54 sm:h-[480px] sm:mt-36
-            w-35 h-[600px] mt-32
+            w-30 h-[500px] mt-20
           "
         >
           <div className="absolute inset-0 z-10 rounded-[40px] overflow-hidden">
@@ -32,7 +32,7 @@ export default function Home() {
               lg:-left-88 lg:w-[355px]
               md:-left-70 md:w-[300px]
               sm:-left-55 sm:w-[260px]
-              -left-35 w-[220px]
+              -left-30 w-[200px]
             "
           >
             <Image
@@ -53,7 +53,7 @@ export default function Home() {
               lg:-right-88 lg:w-[355px]
               md:-right-70 md:w-[300px]
               sm:-right-55 sm:w-[260px]
-              -right-35 w-[220px]
+              -right-30 w-[200px]
             "
           >
             <Image

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -18,7 +18,7 @@ const navItems = [
 export default function BottomNav({bgClass, pathname, altBgClass}: BottomNavProps) {
   return (
     <>
-      <nav className={`w-15/16 h-11 sm:h-16 md:h-20 lg:h-22 ${bgClass} rounded-[40px] mx-auto pl-12 pr-12 absolute bottom-4 left-1/2 transform -translate-x-1/2 transition-colors duration-300 ease-in-out`}>
+      <nav className={`w-15/16 h-11 sm:h-16 md:h-20 lg:h-22 ${bgClass} rounded-[40px] mx-auto pl-4 sm:pl-8 md:pl-12 pr-12 absolute bottom-4 left-1/2 transform -translate-x-1/2 transition-colors duration-300 ease-in-out`}>
         <div className="flex items-center space-evenly h-full w-2/5 justify-between">
             {navItems.map(({ href, src, alt, label }) => {
               const isActive = pathname === href;

--- a/src/components/NavImage.tsx
+++ b/src/components/NavImage.tsx
@@ -21,7 +21,7 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/trees.webp",
     alt: "About page image",
     className: `
-      w-58 h-9
+      w-55 h-9
       sm:w-85 sm:h-14
       md:w-90 md:h-60
       lg:w-135 lg:h-90
@@ -49,14 +49,14 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/buildings.webp",
     alt: "Projects page image",
     className: `
-      w-50 h-140
+      w-55 h-9
       sm:w-50 sm:h-140
       md:w-60 md:h-150
       lg:w-75 lg:h-165
     `,
     text: "Projects",
     textClasses: `
-      bottom-8 right-8
+      bottom-0 right-12
       sm:bottom-8 sm:right-4
       md:bottom-8 md:right-6
       lg:bottom-8 lg:right-12
@@ -66,12 +66,12 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     `,
     position: `
       absolute
-      bottom-3 right-2
+      bottom-1 right-1
       sm:bottom-4 sm:right-2
       md:bottom-5 md:right-2
       lg:bottom-8 lg:right-2
     `,
-    shadow: "shadow-projectsnav-alt shadow-[8px_10px_0_0]"
+    shadow: "sm:shadow-projectsnav-alt sm:shadow-[8px_10px_0_0]"
   },
   "/blog": {
     src: "/imgs/paper.webp",

--- a/src/components/NavImage.tsx
+++ b/src/components/NavImage.tsx
@@ -21,7 +21,8 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/trees.webp",
     alt: "About page image",
     className: `
-      w-55 h-9
+      w-50 h-9
+      xs:w-55 xs:h-9
       sm:w-85 sm:h-14
       md:w-90 md:h-60
       lg:w-135 lg:h-90
@@ -29,7 +30,8 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     `,
     text: "About Me",
     textClasses: `
-      bottom-0 right-12
+      bottom-0.5 right-8
+      xs:bottom-0.5 xs:right-10
       sm:bottom-3 sm:right-12
       md:bottom-8 md:right-12
       text-2xl
@@ -49,14 +51,16 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/buildings.webp",
     alt: "Projects page image",
     className: `
-      w-55 h-9
+      w-50 h-9
+      xs:w-55 xs:h-9
       sm:w-50 sm:h-140
       md:w-60 md:h-150
       lg:w-75 lg:h-165
     `,
     text: "Projects",
     textClasses: `
-      bottom-0 right-12
+      bottom-0.5 right-8
+      xs:bottom-0.5 xs:right-10
       sm:bottom-8 sm:right-4
       md:bottom-8 md:right-6
       lg:bottom-8 lg:right-12

--- a/src/components/NavImage.tsx
+++ b/src/components/NavImage.tsx
@@ -98,26 +98,30 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/bust.webp",
     alt: "Contact page image",
     className: `
-      w-62 h-54
+      w-50 h-9
+      xs:w-55 xs:h-9
       sm:w-84 sm:h-72
       md:w-102 md:h-82
       lg:w-130 lg:h-90
     `,
     text: "Contact",
     textClasses: `
-      bottom-8 right-12
+      bottom-0.5 right-8
+      xs:bottom-0.5 xs:right-10
+      sm:bottom-8 sm:right-12
+      md:bottom-8 md:right-4
       text-2xl
       sm:text-3xl
       md:text-4xl
     `,
     position: `
       absolute
-      bottom-12 left-2
+      bottom-1 right-1
       sm:bottom-15 sm:left-2
       md:bottom-19 md:left-2
       lg:bottom-20 lg:left-2
     `,
-    shadow: "shadow-contactnav-alt shadow-[-8px_10px_0_0]"
+    shadow: "sm:shadow-contactnav-alt sm:shadow-[-8px_10px_0_0]"
   }
 };
 

--- a/src/components/NavImage.tsx
+++ b/src/components/NavImage.tsx
@@ -21,27 +21,29 @@ const imageSettingsByPathname: Record<string, ImageSettings> = {
     src: "/imgs/trees.webp",
     alt: "About page image",
     className: `
-      w-58 h-40
-      sm:w-85 sm:h-58
+      w-58 h-9
+      sm:w-85 sm:h-14
       md:w-90 md:h-60
       lg:w-135 lg:h-90
-      [clip-path:polygon(46%_0%,100%_0%,100%_100%,-20%_100%)]
+      md:[clip-path:polygon(46%_0%,100%_0%,100%_100%,-20%_100%)]
     `,
     text: "About Me",
     textClasses: `
-      bottom-8 right-12
+      bottom-0 right-12
+      sm:bottom-3 sm:right-12
+      md:bottom-8 md:right-12
       text-2xl
       sm:text-3xl
       md:text-4xl
     `,
     position: `
       absolute
-      bottom-3 right-2
-      sm:bottom-3 sm:right-2
+      bottom-1 right-1
+      sm:bottom-1 sm:right-1
       md:bottom-5 md:right-2
       lg:bottom-7 lg:right-2
     `,
-    shadow: "shadow-aboutnav-alt shadow-[8px_10px_0_0]"
+    shadow: "md:shadow-aboutnav-alt md:shadow-[8px_10px_0_0]"
   },
   "/projects": {
     src: "/imgs/buildings.webp",


### PR DESCRIPTION
## Describe the Changes Implemented
This PR adds some tweaks for mobile responsiveness:
1. The landing page content now fits nicely between top and bottom nav elements
2. The `layoutWrapper` component now utilizes `h-dvh` rather than `min-h-screen` in order to account for mobile browser UI elements
3. The `NavImage` component now adjusts to sit nicely inside the `BottomNav` element on mobile screens, leaving plenty of space for page content

## Related Issue
Closes #32 